### PR TITLE
Add GitHub Actions workflow to publish package to PyPI

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,27 @@
+name: Publish to PyPI
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    env:
+      UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
+
+    steps:
+      - name: Install uv
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Build distributions
+        run: uv build
+
+      - name: Publish distributions
+        run: uv publish dist/*


### PR DESCRIPTION
### Motivation
- Automate publishing the Python package to PyPI when a GitHub release is published or when manually triggered.

### Description
- Add `.github/workflows/publish-pypi.yml` which triggers on `release` published and `workflow_dispatch`, installs `uv` via `https://astral.sh/uv/install.sh`, adds `$HOME/.local/bin` to `GITHUB_PATH`, runs `uv build`, and runs `uv publish dist/*` using `UV_PUBLISH_TOKEN` sourced from the `PYPI_API_TOKEN` secret.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c17b9b20c08326a1013efac41f9e01)