### PR TITLE
Check out repository in PyPI publish workflow before running `uv build`

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -15,6 +15,9 @@ jobs:
       UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Install uv
         run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
### Motivation
- Fix CI failure where `uv build` ran without repository contents and could not find `pyproject.toml` or `setup.py`.

### Description
- Add a `- uses: actions/checkout@v4` step to `.github/workflows/publish-pypi.yml` before installing `uv` and running `uv build` so the runner has the repo files on disk.

### Testing
- Ran `uv build` in the repository root; the build completed successfully (created sdist and wheel) though `setuptools` emitted deprecation warnings about `project.license`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1813f066483268c25af562c8bc1eb)