### PR TITLE
Fix release-gate tooling failures in certification lanes

### DIFF
--- a/tools/create_phase9_release_promotion_checkpoint.py
+++ b/tools/create_phase9_release_promotion_checkpoint.py
@@ -241,8 +241,16 @@ def update_markdown_docs() -> None:
     new_section = """## Evidence tiers and promoted release roots\n\nThis archive separates three evidence tiers and binds them to a single current canonical release root:\n\n1. **Local conformance** — `docs/review/conformance/corpus.json`\n2. **Same-stack replay** — `docs/review/conformance/external_matrix.same_stack_replay.json`\n3. **Independent certification** — `docs/review/conformance/external_matrix.release.json`\n\nThe current canonical release root is `docs/review/conformance/releases/0.3.9/release-0.3.9/`.\n\nHistorical preserved roots remain in-tree for provenance:\n\n- `docs/review/conformance/releases/0.3.2/release-0.3.2/`\n- `docs/review/conformance/releases/0.3.6/release-0.3.6/`\n- `docs/review/conformance/releases/0.3.6-current/release-0.3.6-current/`\n- `docs/review/conformance/releases/0.3.6-rfc-hardening/release-0.3.6-rfc-hardening/`\n- `docs/review/conformance/releases/0.3.7/release-0.3.7/`\n\nThe canonical 0.3.9 root contains the full promoted bundle set plus the preserved auxiliary bundles:\n\n- `tigrcorn-independent-certification-release-matrix/`\n- `tigrcorn-same-stack-replay-matrix/`\n- `tigrcorn-mixed-compatibility-release-matrix/`\n- `tigrcorn-flag-surface-certification-bundle/`\n- `tigrcorn-operator-surface-certification-bundle/`\n- `tigrcorn-performance-certification-bundle/`\n- `tigrcorn-certification-environment-bundle/`\n- `tigrcorn-aioquic-adapter-preflight-bundle/`\n- `tigrcorn-strict-validation-bundle/`\n- the preserved local negative / behavior / validation bundles produced during Phases 9C–9E\n\nThe compatibility file `docs/review/conformance/external_matrix.current_release.json` remains a **mixed** matrix because it combines third-party HTTP/1.1 / HTTP/2 peers with same-stack HTTP/3 and RFC 9220 replay fixtures.\n\n"""
     text = replace_section_any(
         text,
-        ('## Evidence tiers shipped with this archive\n', '## Evidence tiers and promoted release roots\n'),
-        ('## Interoperability evidence status in this archive\n', '## Support and certification legend\n'),
+        (
+            '## Evidence tiers shipped with this archive\n',
+            '## Evidence tiers and promoted release roots\n',
+            '## Package boundary, evidence tiers, and support model\n',
+        ),
+        (
+            '## Interoperability evidence status in this archive\n',
+            '## Support and certification legend\n',
+            '## Installation and optional dependency surface\n',
+        ),
         new_section,
     )
     old_scope = """Important scope note:\n\n- Under the current authoritative boundary, RFC 7692, RFC 9110 CONNECT / trailers / content coding, and RFC 6960 are intentionally bounded at `local_conformance` rather than `independent_certification`.\n- Those surfaces are still part of the required RFC surface, and they are satisfied at the tier required by the boundary.\n- A stricter non-authoritative all-surfaces-independent profile would still need additional third-party preserved artifacts.\n- The provisional all-surfaces and flow-control bundles remain in-tree as planning / review aids and do not change the authoritative release-gate result.\n"""

--- a/tools/govchk.py
+++ b/tools/govchk.py
@@ -55,9 +55,24 @@ def scan() -> int:
     folder_max = int(root_cfg.get("folder_name_max", 16))
     path_max = int(root_cfg.get("path_max", 120))
 
+    ignored_dir_names = {
+        ".git",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        ".tox",
+        ".nox",
+        ".venv",
+        "venv",
+        "dist",
+        "build",
+    }
     violations: list[str] = []
     for path in ROOT.rglob("*"):
-        if ".git" in path.parts or "__pycache__" in path.parts or ".pytest_cache" in path.parts:
+        if any(part in ignored_dir_names for part in path.parts):
+            continue
+        if any(part.endswith(".egg-info") for part in path.parts):
             continue
         rel_path = rel(path)
         if is_exempt(path, root_cfg):


### PR DESCRIPTION
### Motivation
- CI certification lanes were failing because repository-generated artifacts from editable installs (e.g., `src/tigrcorn.egg-info`) triggered naming/path governance violations.
- The Phase 9 release-promotion script crashed when it could not find the expected README heading markers, which broke the release-gate workflow.

### Description
- Updated `tools/govchk.py` `scan()` to ignore common generated environment/build/cache directories (examples: `.venv`, `.tox`, `dist`, `build`) and to skip any path part that ends with `.egg-info` so editable-install metadata does not trigger governance failures.
- Tolerant path-filtering is applied early in the glob loop using an `ignored_dir_names` set and a check for `.egg-info` path parts in `tools/govchk.py`.
- Updated `tools/create_phase9_release_promotion_checkpoint.py` to accept the repository's current README layout by adding the alternate start markers (`## Package boundary, evidence tiers, and support model`) and alternate end markers (`## Installation and optional dependency surface`) to the `replace_section_any()` call so the script no longer raises when the legacy headings are not present.

### Testing
- Ran `python tools/govchk.py scan`, which completed successfully (`governance scan passed`).
- Ran `python -m compileall -q src tools tests`, which completed without compile errors.
- Ran the release workflow wrapper `PYTHONPATH=src python tools/run_phase9_release_workflow.py --skip-status-docs --scripts tools/create_phase9i_release_assembly_checkpoint.py`, which completed successfully and no longer raised the previous runtime error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7c98fc3648326a55b9a98f3e4dc95)