### PR TITLE
docs: replace README H1 with centered branding image

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 <div align="center">
 
-# Tigrcorn
+<img
+  src="https://github.com/Tigrbl/tigrcorn/blob/68c5baadd745555de1c6bee70d9b9f3763a7ed3c/assets/tigrcorn_brand_frag_light.png?raw=1"
+  alt="Tigrcorn light branding fragment"
+/>
 
 > Package-owned ASGI3 transport server with audited protocol, operator, release, and certification surfaces.
 


### PR DESCRIPTION
### Motivation
- Replace the top-level `# Tigrcorn` heading with the light branding fragment PNG to present a centered logo and improve accessibility via alt text.

### Description
- Removed the `# Tigrcorn` H1 and inserted a centered `<img>` element that references the provided asset URL with `?raw=1` and includes the alt text "Tigrcorn light branding fragment" in `README.md`.

### Testing
- Ran `python tools/govchk.py state .` which completed successfully (reported repository state).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d1159b448326ad458328bfaea156)