### PR TITLE
docs(readme): add hits.sh badge to centered branding badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 <p align="center">
 <a href="https://pypi.org/project/tigrcorn/"><img alt="PyPI version" src="https://img.shields.io/pypi/v/tigrcorn?label=PyPI"></a> 
 <a href="https://pypi.org/project/tigrcorn/"><img alt="PyPI downloads" src="https://img.shields.io/pepy/dt/tigrcorn?label=downloads"></a> 
+<a href="https://hits.sh/github.com/tigrbl/tigrcorn"><img alt="Project hits badge" src="https://hits.sh/github.com/tigrbl/tigrcorn.svg?label=hits"></a>
 <a href="docs/review/conformance/releases/0.3.9/release-0.3.9/"><img alt="repo line 0.3.9" src="https://img.shields.io/badge/repo_line-0.3.9-2f7ed8"></a> 
 <a href="LICENSE"><img alt="license Apache 2.0" src="https://img.shields.io/badge/license-Apache%202.0-525252"></a>
 <a href="pyproject.toml"><img alt="Python 3.11 supported" src="https://img.shields.io/badge/python-3.11-3776ab"></a> <a href="pyproject.toml"><img alt="Python 3.12 supported" src="https://img.shields.io/badge/python-3.12-3776ab"></a> 


### PR DESCRIPTION
### Motivation
- Add a labeled `hits.sh` badge to the top-centered badge row so the project shows a lightweight public hit/traffic badge while keeping the existing centered branding fragment and alt-text.

### Description
- Inserted a `hits.sh` badge anchor in `README.md` pointing to `https://hits.sh/github.com/tigrbl/tigrcorn.svg?label=hits` and preserved the centered light branding fragment image and its `alt` text.

### Testing
- Ran `git diff -- README.md` and inspected the top of the file with `nl -ba README.md | sed -n '1,40p'` to validate the badge appears in the centered badge row; both checks showed the expected README changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7d1e1ab948326a81d00b7b9e44e6e)