### PR TITLE
Fix CWD app import fallback; add app-load tests and tier-3 claims

### DIFF
--- a/docs/ops/cli.md
+++ b/docs/ops/cli.md
@@ -323,7 +323,7 @@ The rows below mirror the current public flag truth in `docs/review/conformance/
 | Family | `App / process / development` |
 | Config path | `app.app_dir` |
 | Claim class | `pure_operator` |
-| Default | `None` |
+| Default | `None` (loads from current working directory when unset) |
 | RFC targets | — |
 | Validation rules | `path string` |
 | Deployment profiles | `http1_baseline` |

--- a/docs/review/conformance/README.md
+++ b/docs/review/conformance/README.md
@@ -110,6 +110,7 @@ The Phase 2 config / CLI surface is documented in:
 - `optional_dependency_surface.current.json`
 - `DEPLOYMENT_PROFILES.md`
 - `deployment_profiles.json`
+- `app_load_claims.json`
 - `NEXT_DEVELOPMENT_TARGETS.md`
 
 

--- a/docs/review/conformance/app_load_claims.json
+++ b/docs/review/conformance/app_load_claims.json
@@ -1,0 +1,26 @@
+{
+  "surface": "app_import_resolution",
+  "tier_alias": {
+    "tier_3": "independent_certification"
+  },
+  "claims": [
+    {
+      "id": "claim-cwd-module-import",
+      "text": "CLI/server import-string loading resolves module targets from the current working directory when app.app_dir is unset.",
+      "required_evidence_tier": "independent_certification",
+      "current_evidence": "local_conformance",
+      "status": "planned_for_tier_3"
+    },
+    {
+      "id": "claim-cwd-factory-import",
+      "text": "CLI/server factory loading resolves factory targets from the current working directory when app.app_dir is unset.",
+      "required_evidence_tier": "independent_certification",
+      "current_evidence": "local_conformance",
+      "status": "planned_for_tier_3"
+    }
+  ],
+  "local_evidence_tests": [
+    "tests/test_app_loader.py::AppLoaderTests::test_load_app_from_current_working_directory_without_app_dir",
+    "tests/test_app_loader.py::AppLoaderTests::test_load_factory_from_current_working_directory_without_app_dir"
+  ]
+}

--- a/docs/review/conformance/flag_contracts.json
+++ b/docs/review/conformance/flag_contracts.json
@@ -410,7 +410,9 @@
         "http1_baseline"
       ],
       "unit_tests": [
-        "tests/test_phase2_cli_config_surface.py::Phase2CLIConfigSurfaceTests::test_app_dir_round_trip"
+        "tests/test_phase2_cli_config_surface.py::Phase2CLIConfigSurfaceTests::test_app_dir_round_trip",
+        "tests/test_app_loader.py::AppLoaderTests::test_load_app_from_current_working_directory_without_app_dir",
+        "tests/test_app_loader.py::AppLoaderTests::test_load_factory_from_current_working_directory_without_app_dir"
       ],
       "interop_scenarios": [],
       "performance_profiles": [],
@@ -421,7 +423,8 @@
         "current_evidence_state": "operator_bundle_only",
         "promotion_ready": true,
         "release_note": "Runtime surface is wired enough for row-level contracting, but promotion still depends on the composite strict program."
-      }
+      },
+      "release_note": "CWD import-resolution fallback is enforced for module and factory targets when app.app_dir is unset."
     },
     {
       "contract_id": "backlog",

--- a/src/tigrcorn/server/app_loader.py
+++ b/src/tigrcorn/server/app_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import sys
 from contextlib import contextmanager
 
@@ -10,19 +11,20 @@ from tigrcorn.utils.imports import import_from_string
 
 @contextmanager
 def _temporary_app_dir(app_dir: str | None):
-    if not app_dir:
+    effective_app_dir = os.getcwd() if app_dir is None else app_dir
+    if not effective_app_dir:
         yield
         return
     inserted = False
-    if app_dir not in sys.path:
-        sys.path.insert(0, app_dir)
+    if effective_app_dir not in sys.path:
+        sys.path.insert(0, effective_app_dir)
         inserted = True
     try:
         yield
     finally:
         if inserted:
             try:
-                sys.path.remove(app_dir)
+                sys.path.remove(effective_app_dir)
             except ValueError:  # pragma: no cover
                 pass
 

--- a/tests/test_app_loader.py
+++ b/tests/test_app_loader.py
@@ -1,3 +1,6 @@
+import os
+import sys
+import tempfile
 import unittest
 
 from tigrcorn.errors import AppLoadError
@@ -21,3 +24,37 @@ class AppLoaderTests(unittest.TestCase):
     def test_bad_import_raises(self):
         with self.assertRaises(AppLoadError):
             load_app('tests.fixtures_pkg.appmod:missing')
+
+    def test_load_app_from_current_working_directory_without_app_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            app_path = os.path.join(td, 'app.py')
+            with open(app_path, 'w', encoding='utf-8') as handle:
+                handle.write('async def app(scope, receive, send):\n    return None\n')
+            previous = os.getcwd()
+            original_sys_path = list(sys.path)
+            try:
+                os.chdir(td)
+                sys.path[:] = [entry for entry in sys.path if entry not in ('', td)]
+                loaded = load_app('app:app')
+                self.assertTrue(callable(loaded))
+            finally:
+                sys.modules.pop('app', None)
+                sys.path[:] = original_sys_path
+                os.chdir(previous)
+
+    def test_load_factory_from_current_working_directory_without_app_dir(self):
+        with tempfile.TemporaryDirectory() as td:
+            app_path = os.path.join(td, 'app.py')
+            with open(app_path, 'w', encoding='utf-8') as handle:
+                handle.write('def factory():\n    async def app(scope, receive, send):\n        return None\n    return app\n')
+            previous = os.getcwd()
+            original_sys_path = list(sys.path)
+            try:
+                os.chdir(td)
+                sys.path[:] = [entry for entry in sys.path if entry not in ('', td)]
+                loaded = load_app('app:factory', factory=True)
+                self.assertTrue(callable(loaded))
+            finally:
+                sys.modules.pop('app', None)
+                sys.path[:] = original_sys_path
+                os.chdir(previous)


### PR DESCRIPTION
### Motivation
- Resolve a failure to load an app module when running `tigrcorn app:app` from a directory containing `app.py` because the current working directory was not added to `sys.path` when `--app-dir` is unset.  
- Provide regression coverage for both module and factory import-strings when `app_dir` is unset.  
- Record conformance claims that these behaviors require independent (tier-3) certification evidence so the certification matrix can track the work required.

### Description
- Modify `_temporary_app_dir` in `src/tigrcorn/server/app_loader.py` to treat `app_dir=None` as a fallback to the current working directory (`os.getcwd()`), temporarily inserting that directory into `sys.path` for import resolution and removing it afterward.  
- Add two unit tests in `tests/test_app_loader.py` that exercise loading a module and a factory from a temporary CWD without `app_dir` set.  
- Update CLI docs in `docs/ops/cli.md` to clarify that the default `app.app_dir` is `None` and that loading falls back to the current working directory when unset.  
- Add conformance metadata file `docs/review/conformance/app_load_claims.json` with two claims for app-import resolution and mark both as requiring `independent_certification` (tier-3), and wire the new tests into `docs/review/conformance/flag_contracts.json` for the `--app-dir` surface.

### Testing
- Ran unit tests `python -m unittest tests.test_app_loader`, which passed (`OK`).  
- Ran the CLI config unit test `python -m unittest tests.test_phase2_cli_config_surface.Phase2CLIConfigSurfaceTests.test_app_dir_round_trip`, which passed (`OK`).  
- Ran repository state checks with `python tools/govchk.py state` for `src/tigrcorn/server`, `tests`, `docs/review/conformance`, and `docs/ops`, each returning their expected mutable/mixed state (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce3d4d71b8832686683c96bc8d92ad)